### PR TITLE
support color inject

### DIFF
--- a/lib/insert-svg-template.js
+++ b/lib/insert-svg-template.js
@@ -44,6 +44,16 @@ function insertSVGTemplate (index, source, lane, waveSkin, content, lanes, group
     head.viewBox = '0 0 ' + width + ' ' + height;
     head.overflow = 'hidden';
 
+    if (source.color) {
+        let overwrite = '';
+        for (let c in source.color) {
+            if (('vvv-' + c) in lane.clsMap) {
+                overwrite += '.' + lane.clsMap['vvv-' + c] + '{ fill: ' + source.color[c] + ' !important; }';
+            }
+        }
+        e.push(['style', {type: 'text/css'}, overwrite]);
+    }
+
     return e;
 }
 

--- a/lib/render-signal.js
+++ b/lib/render-signal.js
@@ -33,6 +33,14 @@ function laneParamsFromSkin (index, source, lane, waveSkin) {
     lane.ys     = Number(socket.height);
     lane.xlabel = Number(socket.x);
     lane.ym     = Number(socket.y);
+
+    const re = /vvv-\d/;
+    lane.clsMap = skin[3].reduce(function (res, s) {
+        if (re.test(s[1].id)) {
+            res[s[1].id] = s[2][1].class;
+        }
+        return res;
+    }, {});
 }
 
 function renderSignal (index, source, waveSkin, notFirstSignal) {

--- a/test/signal.js
+++ b/test/signal.js
@@ -94,5 +94,18 @@ describe('signal', function () {
         )).to.be.an('array');
         done();
     });
+    it('colors', function (done) {
+        expect(renderAny(3,
+            {
+                signal: [
+                    {name:'clk',         wave: 'p....' },
+                    {name:'Data',        wave: 'x345x', data: 'a b c' },
+                    {name:'Request',     wave: '01..0' }
+                ],
+                color: { 3: '#39C5BB' }
+            }, waveSkin
+        )).to.be.an('array');
+        done();
+    });
 });
 /* eslint-env mocha */


### PR DESCRIPTION
Let user can overwrite waveform color instead of uploading a new theme. Here's the example.

{signal: [
  {name: 'clk', wave: 'p.....|...'},
  {name: 'dat', wave: 'x.234x|=.x', data: ['head', 'body', 'tail', 'data']},
  {name: 'req', wave: '0.1..0|1.1'},
  {},
  {name: 'ack', wave: '1.....|01.'}
], color: {
  '2': 'rgba(255, 0, 0, 0.5)'
}}
