### PR TITLE
Add new syntax "1(5)" to say how much a signal should repeat

### DIFF
--- a/lib/parse-wave-lane.js
+++ b/lib/parse-wave-lane.js
@@ -15,11 +15,7 @@ function parseWaveLane (text, extra, lane) {
     Next  = Stack.shift();
     subCycle = false;
 
-    Repeats = 1;
-    while (Stack[0] === '.' || Stack[0] === '|') { // repeaters parser
-        Stack.shift();
-        Repeats += 1;
-    }
+    Repeats = parseRepetition(Stack)
     R = R.concat(genFirstWaveBrick(Next, extra, Repeats));
 
     while (Stack.length) {
@@ -33,20 +29,7 @@ function parseWaveLane (text, extra, lane) {
             subCycle = false;
             Next = Stack.shift();
         }
-        Repeats = 1;
-        while (Stack[0] === '.' || Stack[0] === '|') { // repeaters parser
-            Stack.shift();
-            Repeats += 1;
-        }
-        if (Stack[0] === '(') {
-            Stack.shift();
-            let number = ''
-            while (Stack[0] !== ')') {
-                number += Stack.shift();
-            }
-            Stack.shift();
-            Repeats = Number(number);
-        }
+        Repeats = parseRepetition(Stack)
         if (subCycle) {
             R = R.concat(genWaveBrick((Top + Next), 0, Repeats - lane.period));
         } else {
@@ -73,6 +56,24 @@ function parseWaveLane (text, extra, lane) {
     // R is array of half brick types, each is item is string
     // num_unseen_markers is how many markers are now unseen due to phase
     return [R, num_unseen_markers];
+}
+
+function parseRepetition(Stack) {
+    let Repeats = 1;
+    while (Stack[0] === '.' || Stack[0] === '|') { // repeaters parser
+        Stack.shift();
+        Repeats += 1;
+    }
+    if (Stack[0] === '(') {
+        Stack.shift();
+        let number = ''
+        while (Stack[0] !== ')' && Stack.length > 0) {
+            number += Stack.shift();
+        }
+        Stack.shift();
+        Repeats += Number(number) - 1;
+    }
+    return Repeats;
 }
 
 module.exports = parseWaveLane;

--- a/lib/parse-wave-lane.js
+++ b/lib/parse-wave-lane.js
@@ -15,7 +15,7 @@ function parseWaveLane (text, extra, lane) {
     Next  = Stack.shift();
     subCycle = false;
 
-    Repeats = parseRepetition(Stack)
+    Repeats = parseRepetition(Stack);
     R = R.concat(genFirstWaveBrick(Next, extra, Repeats));
 
     while (Stack.length) {
@@ -29,7 +29,7 @@ function parseWaveLane (text, extra, lane) {
             subCycle = false;
             Next = Stack.shift();
         }
-        Repeats = parseRepetition(Stack)
+        Repeats = parseRepetition(Stack);
         if (subCycle) {
             R = R.concat(genWaveBrick((Top + Next), 0, Repeats - lane.period));
         } else {
@@ -66,7 +66,7 @@ function parseRepetition(Stack) {
     }
     if (Stack[0] === '(') {
         Stack.shift();
-        let number = ''
+        let number = '';
         while (Stack[0] !== ')' && Stack.length > 0) {
             number += Stack.shift();
         }

--- a/lib/parse-wave-lane.js
+++ b/lib/parse-wave-lane.js
@@ -38,6 +38,15 @@ function parseWaveLane (text, extra, lane) {
             Stack.shift();
             Repeats += 1;
         }
+        if (Stack[0] === '(') {
+            Stack.shift();
+            let number = ''
+            while (Stack[0] !== ')') {
+                number += Stack.shift();
+            }
+            Stack.shift();
+            Repeats = Number(number);
+        }
         if (subCycle) {
             R = R.concat(genWaveBrick((Top + Next), 0, Repeats - lane.period));
         } else {

--- a/lib/render-arcs.js
+++ b/lib/render-arcs.js
@@ -25,13 +25,21 @@ function renderArcs (source, index, top, lane) {
             pos = 0;
             while (stack.length) {
                 eventname = stack.shift();
-                if (eventname !== '.') {
+                if (eventname !== '.' && eventname !== '(') {
                     Events[eventname] = {
                         x: lane.xs *
                           (2 * pos * lane.period * lane.hscale - lane.phase) +
                           lane.xlabel,
                         y: i * lane.yo + lane.y0 + lane.ys * 0.5
                     };
+                }
+                if (eventname === '(') {
+                    let number = ''
+                    while (stack[0] !== ')' && stack.length > 0) {
+                        number += stack.shift();
+                    }
+                    stack.shift();
+                    pos += Number(number) - 2;
                 }
                 pos += 1;
             }

--- a/lib/render-arcs.js
+++ b/lib/render-arcs.js
@@ -34,7 +34,7 @@ function renderArcs (source, index, top, lane) {
                     };
                 }
                 if (eventname === '(') {
-                    let number = ''
+                    let number = '';
                     while (stack[0] !== ')' && stack.length > 0) {
                         number += stack.shift();
                     }

--- a/test/test.html
+++ b/test/test.html
@@ -335,7 +335,7 @@ No <code>gmarks</code>
 ], head:{tick: 1}}
 </script>
 
-<h2>Test 19</h2>
+<h2>Test 19 - Repetition</h2>
 
 <script type="WaveDrom">
 {signal: [
@@ -349,7 +349,9 @@ No <code>gmarks</code>
 <script type="WaveDrom">
 { signal: [
   { name: "repeat", wave: "01(7)0(7)1" },
-  { name: "first brick", wave: "6(3)4(2)5(11)" }
+  { name: "dots + repeat work too", wave: "01..(5)0..(5)1" },
+  { name: "first brick", wave: "6(3)4(2)5(11)" },
+  { name: "wrong syntax no infinite loop", wave: "6(3" }
 ]}
 </script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -89,8 +89,7 @@
   { name: "CMD",  wave: "x.3x=x4x=x=x=x=x", data: "RAS NOP CAS NOP NOP NOP NOP", phase: 0.5 },
   { name: "ADDR", wave: "x.=x..=x........", data: "ROW COL",                     phase: 0.5 },
   { name: "DQS",  wave: "z.......0.1010z." },
-  { name: "DQ",   wave: "z.........5555z.", data: "D0 D1 D2 D3" },
-  { name: "repeat", wave: "01(7)0(7)1" }
+  { name: "DQ",   wave: "z.........5555z.", data: "D0 D1 D2 D3" }
 ]}
 </script>
 
@@ -343,6 +342,15 @@ No <code>gmarks</code>
   {name: 'clk',   wave: 'p.PpPPPPp.P.'},
   {name: 'dat →', wave: 'x.3..4.5...6', data: 'D1 D2 D3'},
 ], head:{tick: -1, every: 5}}
+</script>
+
+<h2>Test 20</h2>
+
+<script type="WaveDrom">
+{ signal: [
+  { name: "repeat", wave: "01(7)0(7)1" },
+  { name: "first brick", wave: "6(3)4(2)5(11)" }
+]}
 </script>
 
 </div>

--- a/test/test.html
+++ b/test/test.html
@@ -89,7 +89,8 @@
   { name: "CMD",  wave: "x.3x=x4x=x=x=x=x", data: "RAS NOP CAS NOP NOP NOP NOP", phase: 0.5 },
   { name: "ADDR", wave: "x.=x..=x........", data: "ROW COL",                     phase: 0.5 },
   { name: "DQS",  wave: "z.......0.1010z." },
-  { name: "DQ",   wave: "z.........5555z.", data: "D0 D1 D2 D3" }
+  { name: "DQ",   wave: "z.........5555z.", data: "D0 D1 D2 D3" },
+  { name: "repeat", wave: "01(7)0(7)1" }
 ]}
 </script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -351,8 +351,10 @@ No <code>gmarks</code>
   { name: "repeat", wave: "01(7)0(7)1" },
   { name: "dots + repeat work too", wave: "01..(5)0..(5)1" },
   { name: "first brick", wave: "6(3)4(2)5(11)" },
-  { name: "wrong syntax no infinite loop", wave: "6(3" }
-]}
+  { name: "wrong syntax no infinite loop", wave: "6(3" },
+  { node: '.A(10)B' },
+  { name: 'works with nodes too', wave: '01(10)0(5)' }
+], edge: [ 'A-B 10ns' ]}
 </script>
 
 </div>


### PR DESCRIPTION
Hello,

Using `.` to repeat signals works great, but I often have to count dots to see how much my signals are repeating. So to make this more explicit and make complex diagrams easier to manage, I would like to propose a new syntax, which explicitly supports specifying the number of repeats for a signal:

```bash
# with dots
"1.........."
# with new syntax
"1(10)"
```

Here is what the new test case looks like:

<img width="863" alt="Screenshot 2021-09-30 at 22 05 01" src="https://user-images.githubusercontent.com/70469/135523003-5f686244-7f99-4c6a-942e-b75a0fde6fad.png">

@drom I hope this is interesting to you. Let me know if you have any questions or suggestions.