### PR TITLE
Display ticks/tocks once every N cycles

### DIFF
--- a/lib/render-marks.js
+++ b/lib/render-marks.js
@@ -78,6 +78,9 @@ function ticktock (cxt, ref1, ref2, x, dx, y, len) {
     }];
 
     for (i = 0; i < len; i += 1) {
+        if (cxt[ref1] && cxt[ref1].every && (i + offset) % cxt[ref1].every != 0) {
+            continue
+        }
         res.push(['text', {x: i * dx + x, y: y}].concat(tspan.parse(L[i])));
     }
     return [res];

--- a/test/test.html
+++ b/test/test.html
@@ -335,6 +335,15 @@ No <code>gmarks</code>
 ], head:{tick: 1}}
 </script>
 
+<h2>Test 19</h2>
+
+<script type="WaveDrom">
+{signal: [
+  {name: 'clk',   wave: 'p.PpPPPPp.P.'},
+  {name: 'dat →', wave: 'x.3..4.5...6', data: 'D1 D2 D3'},
+], head:{tick: -1, every: 5}}
+</script>
+
 </div>
 
 <script>(function(){ window.addEventListener("load", WaveDrom.ProcessAll, false); })();</script>


### PR DESCRIPTION
Hello,

This MR adds a new option in both `head` and `foot` to display ticks and tocks only once every N cycles. This is what it looks like: 

<img width="589" alt="Screenshot 2021-10-03 at 13 39 49" src="https://user-images.githubusercontent.com/70469/135752033-bc9dd853-3942-43af-9f5f-f1fe3e0951d6.png">

@drom I hope you find this interesting! Let me know if you have any questions or suggestions.

