### PR TITLE
Use case insensitive scan for script type attribute WaveDrom (issue #…

### DIFF
--- a/lib/process-all.js
+++ b/lib/process-all.js
@@ -17,7 +17,7 @@ function processAll () {
     index = 0; // actual number of valid anchor
     points = document.querySelectorAll('*');
     for (i = 0; i < points.length; i++) {
-        if (points.item(i).type && points.item(i).type === 'WaveDrom') {
+        if (points.item(i).type && points.item(i).type.toLowerCase() === 'wavedrom') {
             points.item(i).setAttribute('id', 'InputJSON_' + index);
 
             node0 = document.createElement('div');


### PR DESCRIPTION
…343)

Fix for issue #343

HTML attributes are case insensitive, thus the scan for the type attribute of the script tag should be case insensitive.
Using the version <script type="WaveDrom"></script>, can cause problems when feed through a minification process of html generated from markdown.
E.g. by embedding in a hugo (https://gohugo.io/) based blog.

Please reference to the Issue you are fixing with this PR.
