### PR TITLE
Fix regression: WaveDrom doesnt display errors on incorrect WaveJSON anymore #312

### DIFF
--- a/lib/eva.js
+++ b/lib/eva.js
@@ -4,7 +4,7 @@ function eva (id) {
     var TheTextBox, source;
 
     function erra (e) {
-        console.log("Error in WaveJS: ", e);
+        console.log('Error in WaveJS: ', e);
         var msg = ['tspan', ['tspan', {class:'error h5'}, 'Error: '], e.message];
         msg.textWidth = 1000;  // set dummy width because we cannot measure tspans
         return { signal: [{ name: msg }]};
@@ -42,3 +42,4 @@ function eva (id) {
 module.exports = eva;
 
 /* eslint-env browser */
+/* eslint no-console: 0 */

--- a/lib/eva.js
+++ b/lib/eva.js
@@ -4,6 +4,7 @@ function eva (id) {
     var TheTextBox, source;
 
     function erra (e) {
+        console.log("Error in WaveJS: ", e);
         var msg = ['tspan', ['tspan', {class:'error h5'}, 'Error: '], e.message];
         msg.textWidth = 1000;  // set dummy width because we cannot measure tspans
         return { signal: [{ name: msg }]};

--- a/lib/eva.js
+++ b/lib/eva.js
@@ -4,7 +4,9 @@ function eva (id) {
     var TheTextBox, source;
 
     function erra (e) {
-        return { signal: [{ name: ['tspan', ['tspan', {class:'error h5'}, 'Error: '], e.message] }]};
+        var msg = ['tspan', ['tspan', {class:'error h5'}, 'Error: '], e.message];
+        msg.textWidth = 1000;  // set dummy width because we cannot measure tspans
+        return { signal: [{ name: msg }]};
     }
 
     TheTextBox = document.getElementById(id);

--- a/lib/render-wave-lane.js
+++ b/lib/render-wave-lane.js
@@ -75,7 +75,7 @@ function renderWaveLane (content, index, lane) {
             );
 
             xmax = Math.max(xmax, (el[1] || []).length);
-            glengths.push(textWidth(name, 11));
+            glengths.push(name.textWidth ? name.textWidth : name.charCodeAt ? textWidth(name, 11) : 0);
         }
     });
     // xmax if no xmax_cfg,xmin_cfg, else set to config


### PR DESCRIPTION
WaveDrom uses tspans to display error messages. They don't work anymore (see issue #299). Issue #312 is for the missing error messages.

This was working before because we were building DOM elements and then we could use `title.getBBox().width` to get their width (see [this line](https://github.com/wavedrom/wavedrom/commit/acee81d4329fe0e0e3aeb516dac09308f4227319#diff-10603f6f83ac716421890cbdae1a2419525bc81109ee3285af43a75866e8bebcL49)). We cannot do this anymore because we only have the tspan lists at this point. The current code uses `textWidth`, which will fail for anything that is not a simple string.

This PR skips measuring the width for non-strings. This will avoid the failing call to `textWidth` but we still don't have a proper width for tspan names. This will be good enough as long as their is some non-tspan name that is wider. If not, the user must set `textWidth` on the tspan list to provide an explicit width.

The error messages set this to 1000, which is certainly not right but good enough to show the error message. It isn't pretty but at least we tell the user about the error.

Alternatives:
- Add the `textWidth` to the tspan in a less sneaky way.
- Measure at a later point or make a temporary DOM element that we can measure. This will only work in the browser, I think.
- Don't use a dummy signal to display error messages, e.g. add this as a special case in the rendering code.

While the alternatives are arguably more clean than my fix, they need more changes to the code and more tests to make sure that existing use cases don't break. This PR only changes cases that were broken anyway. I suggest that we merge this quick fix and maybe add a proper fix later (if tspans are used often or if we find error message that are not readable with my simple fix).