### PR TITLE
Fix link to WaveJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ From a CDN:
 <body onload="WaveDrom.ProcessAll()">
 ```
 
-3) Insert [WaveJSON](https://github.com/wavedrom/schema/blob/trunk/WaveJSON.md) source inside HTML ``<body>`` wrapped with the ``<script>`` tag:
+3) Insert [WaveJSON](https://github.com/wavedrom/schema/blob/master/WaveJSON.md) source inside HTML ``<body>`` wrapped with the ``<script>`` tag:
 
 ```html
 <script type="WaveDrom">


### PR DESCRIPTION
The current link leads to nothing (error 404).
I updated it so that both WaveJSON references (line 15 & 75) lead to the same URL.