### PR TITLE
Use insertAdjacentHTML in processAll function

### DIFF
--- a/lib/process-all.js
+++ b/lib/process-all.js
@@ -31,7 +31,7 @@ function processAll () {
         appendSaveAsDialog(i, 'WaveDrom_Display_');
     }
     // add styles
-    document.head.innerHTML += '<style type="text/css">div.wavedromMenu{position:fixed;border:solid 1pt#CCCCCC;background-color:white;box-shadow:0px 10px 20px #808080;cursor:default;margin:0px;padding:0px;}div.wavedromMenu>ul{margin:0px;padding:0px;}div.wavedromMenu>ul>li{padding:2px 10px;list-style:none;}div.wavedromMenu>ul>li:hover{background-color:#b5d5ff;}</style>';
+    document.head.insertAdjacentHTML('beforeend', '<style type="text/css">div.wavedromMenu{position:fixed;border:solid 1pt#CCCCCC;background-color:white;box-shadow:0px 10px 20px #808080;cursor:default;margin:0px;padding:0px;}div.wavedromMenu>ul{margin:0px;padding:0px;}div.wavedromMenu>ul>li{padding:2px 10px;list-style:none;}div.wavedromMenu>ul>li:hover{background-color:#b5d5ff;}</style>');
 }
 
 module.exports = processAll;


### PR DESCRIPTION
Please reference to the Issue you are fixing with this PR.

Currently, the `processAll` function in `lib/process-all.js` directly modifies the document.head.innerHTML. This means that the browser will reparse the content in the `<head>`, causing stylesheets (e.g., `link rel="stylesheet"`) to be reloaded. In cases of slow network speeds, the page's styles can be lost during the CSS reloading process, negatively impacting the user experience. By using insertAdjacentHTML instead, this problem can be resolved.