### PR TITLE
Add color and background to menu style to ensure contrast

### DIFF
--- a/lib/process-all.js
+++ b/lib/process-all.js
@@ -31,7 +31,7 @@ function processAll () {
         appendSaveAsDialog(i, 'WaveDrom_Display_');
     }
     // add styles
-    document.head.insertAdjacentHTML('beforeend', '<style type="text/css">div.wavedromMenu{position:fixed;border:solid 1pt#CCCCCC;background-color:white;box-shadow:0px 10px 20px #808080;cursor:default;margin:0px;padding:0px;}div.wavedromMenu>ul{margin:0px;padding:0px;}div.wavedromMenu>ul>li{padding:2px 10px;list-style:none;}div.wavedromMenu>ul>li:hover{background-color:#b5d5ff;}</style>');
+    document.head.insertAdjacentHTML('beforeend', '<style type="text/css">div.wavedromMenu{position:fixed;border:solid 1pt#CCCCCC;background-color:white;box-shadow:0px 10px 20px #808080;cursor:default;margin:0px;padding:0px;}div.wavedromMenu>ul{margin:0px;padding:0px;}div.wavedromMenu>ul>li{padding:2px 10px;list-style:none;color:#000000;background-color:#ffffff;}div.wavedromMenu>ul>li:hover{color:#000000;background-color:#b5d5ff;}</style>');
 }
 
 module.exports = processAll;


### PR DESCRIPTION
Addresses Issue #366 by setting an explicit text and background color. May not be the nicest on the eyes while in a dark mode, but ensures readability, which is more important.
