### PR TITLE
Fix Save as PNG canvas drawing

### DIFF
--- a/lib/append-save-as-dialog.js
+++ b/lib/append-save-as-dialog.js
@@ -52,24 +52,29 @@ function appendSaveAsDialog (index, output) {
                         html += firstDiv.innerHTML.substring(166, firstDiv.innerHTML.indexOf('<g id="waves_0">'));
                     }
                     html = [div.innerHTML.slice(0, 166), html, div.innerHTML.slice(166)].join('');
-                    const svgdata = 'data:image/svg+xml;base64,' + btoa(html);
+                    const svgdata = 'data:image/svg+xml;base64,' +
+                        btoa(encodeURIComponent(html).replace(/%([0-9A-F]{2})/g, (_, p1) =>
+                            String.fromCharCode(parseInt(p1, 16))
+                        ));
                     const img = new Image();
                     img.src = svgdata;
-                    const canvas = document.createElement('canvas');
-                    canvas.width = img.width;
-                    canvas.height = img.height;
-                    const context = canvas.getContext('2d');
-                    context.drawImage(img, 0, 0);
+                    img.onload = function () {
+                        const canvas = document.createElement('canvas');
+                        canvas.width = img.width;
+                        canvas.height = img.height;
+                        const context = canvas.getContext('2d');
+                        context.drawImage(img, 0, 0);
 
-                    const pngdata = canvas.toDataURL('image/png');
+                        const pngdata = canvas.toDataURL('image/png');
 
-                    const a = document.createElement('a');
-                    a.href = pngdata;
-                    a.download = 'wavedrom.png';
-                    a.click();
+                        const a = document.createElement('a');
+                        a.href = pngdata;
+                        a.download = 'wavedrom.png';
+                        a.click();
 
-                    menu.parentNode.removeChild(menu);
-                    document.body.removeEventListener('mousedown', closeMenu, false);
+                        menu.parentNode.removeChild(menu);
+                        document.body.removeEventListener('mousedown', closeMenu, false);
+                    };
                 },
                 false
             );


### PR DESCRIPTION
Since img loading is asynchronous, on some browsers/engines, img.width is not defined yet when doing canvas.width = img.width. Moving the process inside img.onload ensures the image is loaded and the width can be read properly.